### PR TITLE
Add opacity to error hr

### DIFF
--- a/scss/_error.scss
+++ b/scss/_error.scss
@@ -9,6 +9,7 @@
   hr {
     max-width: 20rem;
     margin: 2rem 0;
+    opacity: 1;
   }
 
   a {


### PR DESCRIPTION
### Summary
The `<hr />` tag inherits the opacity from `_reboot.scss` so needs its own value setting
![image](https://user-images.githubusercontent.com/81559178/136559124-997d6079-dad3-4a46-90dc-12b807768aff.png)
