### PR TITLE
fix(TA-471): typo in branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,4 +100,4 @@ workflows:
           filters:
             branches:
               only:
-                -main
+                - main


### PR DESCRIPTION
#### Problem
Needed to fix a type in the branch name as needed a space

#### Example
(example or details of how to recreate the issue)

(screenshots of new/changed behaviour if applicable)

#### Change/Fix
(how this PR attempts to fix the issue or add the desired change)

#### Checklist
- [ ] PO review
- [ ] UX review
- [ ] Accessibility review (See: https://github.com/talis/elevate-app/wiki/Accessibility)
