### PR TITLE
fix: replacing nav tab underlines with a border instead of a background gradient

### DIFF
--- a/scss/_navs.scss
+++ b/scss/_navs.scss
@@ -10,7 +10,7 @@
   }
 
   .nav-link.active {
-    background-image: linear-gradient(0deg, #017d87 4px, transparent 4px);
+    border-bottom: 4px solid $primary;
   }
 
   .nav-link:focus {


### PR DESCRIPTION
#### Problem
Part of the work on https://techfromsage.atlassian.net/browse/TA-1919

it's not possible to change the colour of the tab underlines with a separate css rule due to how it's implemented as a background gradient image. The tabs I'm referring to are these:

<img width="354" alt="image" src="https://github.com/user-attachments/assets/30470452-fc75-4ab3-a8fd-d224943ac6cf" />

specifically the thick (4px) underline on the selected tab.

#### Change/Fix
This PR replaces it with a 4px border. They look identical to me, I've tested the update in Otis so I can see it still behaves correctly with working tabs (the tabs in the kitchen sink demo are not functional).

#### Checklist
- [ ] PO review
- [ ] Branch build
- [ ] UX review
- [ ] Accessibility review (See: https://github.com/talis/elevate-app/wiki/Accessibility)
